### PR TITLE
fix: API 연결 및 태그로 카페 목록 필터링 시 에러뜨는 오류 수정 #29

### DIFF
--- a/src/pages/cafe/CafeDetailPage.tsx
+++ b/src/pages/cafe/CafeDetailPage.tsx
@@ -33,12 +33,12 @@ export interface CafeDetail extends CafeBase {
   limitTime: number;          // 시간 제한
   phoneNumber: string;        // 전화번호
   tags: {
-    petFriendly: boolean;     // 반려견 동반 가능 여부
+    petFriendly: boolean; // 반려견 동반 가능 여부
     power_outlet_level: string; // 콘센트 수준
   };
-  menuList: Menu[];           // 메뉴 리스트
-  imageList: ImageData[];     // 이미지 리스트
-  location: number[];         // [lng, lat]
+  menuList: Menu[]; // 메뉴 리스트
+  imageList: ImageData[]; // 이미지 리스트
+  location: number[]; // [lng, lat]
 }
 
 // 리뷰 타입
@@ -51,10 +51,18 @@ interface Review {
 
 interface CafeReviews {
   averageStarRating?: number; // 평균 별점
-  reviewCount?: number;       // 리뷰 개수
+  reviewCount?: number; // 리뷰 개수
   reviews?: Review[];
 }
+// ----------------------
+// 이미지 url 처리 함수
+// ----------------------
 
+const BASE_IMAGE_URL = "https://tmp.studyspot.kr";
+const getFullImageUrl = (url: string) => {
+  if (!url) return "";
+  return url.startsWith("http") ? url : `${BASE_IMAGE_URL}${url}`;
+};
 // ----------------------
 // 글로벌 window 타입 선언 필요 (naver 지도)
 // ----------------------
@@ -123,7 +131,10 @@ export default function CafeDetailPage() {
     });
 
     new window.naver.maps.Marker({
-      position: new window.naver.maps.LatLng(cafe.location[1], cafe.location[0]),
+      position: new window.naver.maps.LatLng(
+        cafe.location[1],
+        cafe.location[0]
+      ),
       map,
     });
   }, [cafe]);
@@ -140,7 +151,7 @@ export default function CafeDetailPage() {
       {/* 이미지 슬라이더 */}
       <div className="slider">
         <img
-          src={cafe.imageList[currentImage]?.imageUrl}
+          src={getFullImageUrl(cafe.imageList[currentImage]?.imageUrl)}
           alt="카페 이미지"
           className="slider-img"
         />
@@ -193,7 +204,11 @@ export default function CafeDetailPage() {
       <div className="menu-grid">
         {cafe.menuList.map((m: Menu, i: number) => (
           <div key={i} className="menu-card">
-            <img src={m.imageUrl} alt={m.name} className="menu-img" />
+            <img
+              src={getFullImageUrl(m.imageUrl)}
+              alt={m.name}
+              className="menu-img"
+            />
             <h3 className="menu-title">{m.name}</h3>
             <p className="menu-desc">{m.description}</p>
             <p className="menu-price">{m.price}원</p>
@@ -220,7 +235,9 @@ export default function CafeDetailPage() {
             <div key={i} className="review-card">
               <b>{r.name}</b> ⭐ {r.starRating}
               <p>{r.content}</p>
-              {r.imageUrl && <img src={r.imageUrl} alt="리뷰 이미지" />}
+              {r.imageUrl && (
+                <img src={getFullImageUrl(r.imageUrl)} alt="리뷰 이미지" />
+              )}
             </div>
           ))}
         </div>
@@ -230,8 +247,7 @@ export default function CafeDetailPage() {
       <h2 className="section-title">위치</h2>
       <div ref={mapRef} className="naver-map"></div>
 
-       <BottomNav />
+      <BottomNav />
     </div>
-
   );
 }

--- a/src/pages/search/TagSearchPage.tsx
+++ b/src/pages/search/TagSearchPage.tsx
@@ -4,12 +4,8 @@ import React, { useState, useEffect, KeyboardEvent } from "react";
 import BottomNav from "../../components/BottomNav";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
-import { getTags } from "../../api/cafeApi";
 import CafeCard from "../../components/cafe/CafeCard";
-import {
-  normalizeCafe,
-  CafeCardData,
-} from "../../components/utils/normalizeCafe";
+import { normalizeCafe, CafeCardData } from "../../components/utils/normalizeCafe";
 
 const TAG_MAP: { [key: string]: string[] } = {
   "☕️ 공간종류": ["카페", "스터디카페", "독서실"],
@@ -49,36 +45,9 @@ const TagSearchPage: React.FC = () => {
   const [showResult, setShowResult] = useState(false);
   const [results, setResults] = useState<CafeCardData[]>([]);
   const [showAddTags, setShowAddTags] = useState(false);
-  const normalizedResults: CafeCardData[] = results.map(normalizeCafe);
 
-  const [tagsMap, setTagsMap] = useState<{ [key: string]: string[] }>(TAG_MAP);
-
-  // ---------------------
-  // 태그 API 호출
-  // ---------------------
-  useEffect(() => {
-    const fetchTags = async () => {
-      try {
-        const categories = Object.keys(TAG_MAP);
-        const newTagsMap: { [key: string]: string[] } = {};
-
-        for (const category of categories) {
-          const tagsFromApi = await getTags(category); // searchPhrase 기반
-          newTagsMap[category] = tagsFromApi.length
-            ? tagsFromApi
-            : TAG_MAP[category];
-        }
-
-        setTagsMap(newTagsMap);
-      } catch (err) {
-        console.error("[ERROR] 태그 불러오기 실패:", err);
-        setTagsMap(TAG_MAP);
-      }
-    };
-    fetchTags();
-  }, []);
-
-  const SPACE_TAGS = new Set(tagsMap["☕️ 공간종류"] || []);
+  const tagsMap = TAG_MAP; // API 없이 TAG_MAP만 사용
+  const SPACE_TAGS = new Set(tagsMap["☕️ 공간종류"]);
 
   const toggleTag = (tag: string) => {
     setSelectedTags((prev) =>
@@ -105,6 +74,12 @@ const TagSearchPage: React.FC = () => {
   // ---------------------
   const executeSearch = async () => {
     try {
+      if (!storeQuery && selectedTags.length === 0) {
+        setResults([]);
+        setShowResult(false);
+        return;
+      }
+
       const params = new URLSearchParams();
       if (storeQuery) params.append("nameOfCafe", storeQuery);
       if (selectedTags.length)
@@ -118,15 +93,24 @@ const TagSearchPage: React.FC = () => {
         ? res.data.data.cafes
         : [];
 
-      // ★ normalizeCafe 적용 ★
       const normalized = cafes.map(normalizeCafe);
 
-      setResults(normalized);
+      // 선택된 태그 필터링
+      const filtered = selectedTags.length
+        ? normalized.filter((cafe) =>
+            selectedTags.every((tag) => {
+              if (SPACE_TAGS.has(tag)) return cafe.category === tag;
+              return cafe.tags?.includes(tag);
+            })
+          )
+        : normalized;
+
+      setResults(filtered);
       setShowResult(true);
     } catch (err) {
       console.error("[ERROR] 카페 검색 실패:", err);
       setResults([]);
-      setShowResult(true);
+      setShowResult(false);
     }
   };
 
@@ -138,18 +122,12 @@ const TagSearchPage: React.FC = () => {
     if (showResult) executeSearch();
   }, [selectedTags]);
 
-  // ---------------------
-  // 영업중 계산 함수
-  // ---------------------
   const checkOpenStatus = (start?: string, end?: string) => {
     if (!start || !end) return "정보없음";
-
     const now = new Date();
     const current = now.getHours() * 60 + now.getMinutes();
-
     const [sh, sm] = start.split(":").map(Number);
     const [eh, em] = end.split(":").map(Number);
-
     const startMin = sh * 60 + sm;
     const endMin = eh * 60 + em;
 

--- a/src/pages/search/TagSearchPage.tsx
+++ b/src/pages/search/TagSearchPage.tsx
@@ -5,7 +5,10 @@ import BottomNav from "../../components/BottomNav";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import CafeCard from "../../components/cafe/CafeCard";
-import { normalizeCafe, CafeCardData } from "../../components/utils/normalizeCafe";
+import {
+  normalizeCafe,
+  CafeCardData,
+} from "../../components/utils/normalizeCafe";
 
 const TAG_MAP: { [key: string]: string[] } = {
   "☕️ 공간종류": ["카페", "스터디카페", "독서실"],
@@ -72,57 +75,56 @@ const TagSearchPage: React.FC = () => {
   // ---------------------
   // 검색 실행
   // ---------------------
-const executeSearch = async () => {
-  try {
-    if (!storeQuery && selectedTags.length === 0) {
-      console.log("[INFO] 검색 조건 없음");
+  const executeSearch = async () => {
+    try {
+      if (!storeQuery && selectedTags.length === 0) {
+        console.log("[INFO] 검색 조건 없음");
+        setResults([]);
+        setShowResult(false);
+        return;
+      }
+
+      const params = new URLSearchParams();
+      if (storeQuery) params.append("nameOfCafe", storeQuery);
+      if (selectedTags.length)
+        selectedTags.forEach((tag) => params.append("tags", tag));
+
+      console.log("[DEBUG] 검색 파라미터:", params.toString());
+
+      const res = await axios.get<{ data: { cafes: Cafe[] } }>(
+        `https://studyspot.kr/api/cafes?${params.toString()}`
+      );
+
+      console.log("[DEBUG] API 응답 데이터:", res.data);
+
+      const cafes = Array.isArray(res.data.data?.cafes)
+        ? res.data.data.cafes
+        : [];
+
+      const normalized = cafes.map(normalizeCafe);
+
+      console.log("[DEBUG] 정규화된 결과:", normalized);
+
+      const filtered = selectedTags.length
+        ? normalized.filter((cafe) =>
+            selectedTags.every((tag) => {
+              if (SPACE_TAGS.has(tag)) return cafe.category === tag;
+              // cafe.tags가 객체일 경우 Object.values 사용
+              return Object.values(cafe.tags || {}).includes(tag);
+            })
+          )
+        : normalized;
+
+      console.log("[DEBUG] 필터링된 결과:", filtered);
+
+      setResults(filtered);
+      setShowResult(true);
+    } catch (err) {
+      console.error("[ERROR] 카페 검색 실패:", err);
       setResults([]);
       setShowResult(false);
-      return;
     }
-
-    const params = new URLSearchParams();
-    if (storeQuery) params.append("nameOfCafe", storeQuery);
-    if (selectedTags.length)
-      selectedTags.forEach((tag) => params.append("tags", tag));
-
-    console.log("[DEBUG] 검색 파라미터:", params.toString());
-
-    const res = await axios.get<{ data: { cafes: Cafe[] } }>(
-      `https://studyspot.kr/api/cafes?${params.toString()}`
-    );
-
-    console.log("[DEBUG] API 응답 데이터:", res.data);
-
-    const cafes = Array.isArray(res.data.data?.cafes)
-      ? res.data.data.cafes
-      : [];
-
-    const normalized = cafes.map(normalizeCafe);
-
-    console.log("[DEBUG] 정규화된 결과:", normalized);
-
-    const filtered = selectedTags.length
-      ? normalized.filter((cafe) =>
-          selectedTags.every((tag) => {
-            if (SPACE_TAGS.has(tag)) return cafe.category === tag;
-            // cafe.tags가 객체일 경우 Object.values 사용
-            return Object.values(cafe.tags || {}).includes(tag);
-          })
-        )
-      : normalized;
-
-    console.log("[DEBUG] 필터링된 결과:", filtered);
-
-    setResults(filtered);
-    setShowResult(true);
-  } catch (err) {
-    console.error("[ERROR] 카페 검색 실패:", err);
-    setResults([]);
-    setShowResult(false);
-  }
-};
-
+  };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") executeSearch();

--- a/src/pages/search/TagSearchPage.tsx
+++ b/src/pages/search/TagSearchPage.tsx
@@ -72,47 +72,57 @@ const TagSearchPage: React.FC = () => {
   // ---------------------
   // 검색 실행
   // ---------------------
-  const executeSearch = async () => {
-    try {
-      if (!storeQuery && selectedTags.length === 0) {
-        setResults([]);
-        setShowResult(false);
-        return;
-      }
-
-      const params = new URLSearchParams();
-      if (storeQuery) params.append("nameOfCafe", storeQuery);
-      if (selectedTags.length)
-        selectedTags.forEach((tag) => params.append("tags", tag));
-
-      const res = await axios.get<{ data: { cafes: Cafe[] } }>(
-        `https://studyspot.kr/api/cafes?${params.toString()}`
-      );
-
-      const cafes = Array.isArray(res.data.data?.cafes)
-        ? res.data.data.cafes
-        : [];
-
-      const normalized = cafes.map(normalizeCafe);
-
-      // 선택된 태그 필터링
-      const filtered = selectedTags.length
-        ? normalized.filter((cafe) =>
-            selectedTags.every((tag) => {
-              if (SPACE_TAGS.has(tag)) return cafe.category === tag;
-              return cafe.tags?.includes(tag);
-            })
-          )
-        : normalized;
-
-      setResults(filtered);
-      setShowResult(true);
-    } catch (err) {
-      console.error("[ERROR] 카페 검색 실패:", err);
+const executeSearch = async () => {
+  try {
+    if (!storeQuery && selectedTags.length === 0) {
+      console.log("[INFO] 검색 조건 없음");
       setResults([]);
       setShowResult(false);
+      return;
     }
-  };
+
+    const params = new URLSearchParams();
+    if (storeQuery) params.append("nameOfCafe", storeQuery);
+    if (selectedTags.length)
+      selectedTags.forEach((tag) => params.append("tags", tag));
+
+    console.log("[DEBUG] 검색 파라미터:", params.toString());
+
+    const res = await axios.get<{ data: { cafes: Cafe[] } }>(
+      `https://studyspot.kr/api/cafes?${params.toString()}`
+    );
+
+    console.log("[DEBUG] API 응답 데이터:", res.data);
+
+    const cafes = Array.isArray(res.data.data?.cafes)
+      ? res.data.data.cafes
+      : [];
+
+    const normalized = cafes.map(normalizeCafe);
+
+    console.log("[DEBUG] 정규화된 결과:", normalized);
+
+    const filtered = selectedTags.length
+      ? normalized.filter((cafe) =>
+          selectedTags.every((tag) => {
+            if (SPACE_TAGS.has(tag)) return cafe.category === tag;
+            // cafe.tags가 객체일 경우 Object.values 사용
+            return Object.values(cafe.tags || {}).includes(tag);
+          })
+        )
+      : normalized;
+
+    console.log("[DEBUG] 필터링된 결과:", filtered);
+
+    setResults(filtered);
+    setShowResult(true);
+  } catch (err) {
+    console.error("[ERROR] 카페 검색 실패:", err);
+    setResults([]);
+    setShowResult(false);
+  }
+};
+
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") executeSearch();

--- a/src/styles/search/TagSearchPage.css
+++ b/src/styles/search/TagSearchPage.css
@@ -15,10 +15,9 @@
   box-sizing: border-box;
   overflow: hidden;
   height: fit-content;
-  
 }
 .ai-input {
-  border: 1px solid #e4afaf;
+  /* border: 1px solid #e4afaf; */
   border-radius: 12px;
 }
 /* 상단 탭 */
@@ -44,7 +43,6 @@
 .search-tabs button.active {
   border-bottom: 3px solid #e4afaf;
   color: #e4afaf;
-
 }
 
 /* 선택된 태그 영역 */
@@ -101,10 +99,12 @@
 /* 선택된 태그 색상 */
 .tag.space-type.active {
   background-color: #c6eac3;
+  border: none;
 }
 
 .tag.active:not(.space-type) {
   background-color: #e58c8c;
+  border: none;
   color: #fff;
 }
 
@@ -194,8 +194,6 @@ button.ai-input {
 
 button.ai-input:hover {
   background-color: #e4afaf;
-
-
 }
 
 /* 검색 결과 카드 */


### PR DESCRIPTION
🧩 관련 Issue
Closes #29 

---

🎯
 작업 개요
백엔드에서 api를 통해 데이터 불러올때 태그로 검색시 공간종류와 그 외 태그들을 분리하는 작업  수행
태그로 카페 목록들 중 선택한 태그와 일치하는 카페들 검색 후 출력
---

🔍
 상세 내용
변경된 코드 주요 요약
세부 구현 내용
참고한 자료나 문서

---

✅
 체크리스트
[ ] 기능이 정상 동작한다
[ ] 테스트 코드 통과
[ ] 코드 리뷰 반영 완료
[ ] 스타일 가이드 준수

---

💬
 참고 사항
관련 문서/링크
디자인/기획 참고 위치
기타 전달 사항